### PR TITLE
Base64 instead of URL encoding

### DIFF
--- a/background.js
+++ b/background.js
@@ -131,7 +131,7 @@ function headerRecv(responseDetails) {
 		filename: filename,
 		mode: mode,
 	};
-	var url = dispositionPage + "#" + encodeURIComponent(JSON.stringify(params));
+	var url = dispositionPage + "#" + btoa(JSON.stringify(params));
 
 	browser.tabs.update(responseDetails.tabId, {url: url});
 

--- a/dispatch.js
+++ b/dispatch.js
@@ -24,7 +24,7 @@
  * ***** END LICENSE BLOCK ***** */
 
 function getParams() {
-	return JSON.parse(decodeURIComponent(window.location.hash.substring(1)));
+	return JSON.parse(atob(window.location.hash.substring(1)));
 }
 
 function action(ev) {


### PR DESCRIPTION
I'd propose to base64 encode the data for dispatch.html instead of just URL encode it. Visually it looks "better".