### PR TITLE
UTF-8 Content-Disposition handling via jshttp/content-disposition and raw UTF-8 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /.idea
 /*.xpi
+
+node_modules
+
+/content-disposition.js

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,8 @@ TARGET_XPI = $(NAME)-$(VERSION).xpi
 xpi:
 	git archive --format zip -o $(TARGET_XPI) HEAD -- .
 
-.PHONY: xpi
+all:
+	npm install
+	npm run build
+
+.PHONY: xpi all

--- a/content-disposition-in.js
+++ b/content-disposition-in.js
@@ -1,0 +1,1 @@
+window.contentDisposition = require('content-disposition');

--- a/dispatch.js
+++ b/dispatch.js
@@ -24,7 +24,7 @@
  * ***** END LICENSE BLOCK ***** */
 
 function getParams() {
-	return JSON.parse(atob(window.location.hash.substring(1)));
+	return JSON.parse(decodeURIComponent(escape(atob(window.location.hash.substring(1)))));
 }
 
 function action(ev) {

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,6 @@
   ],
 
   "background": {
-    "scripts": ["choices.js", "background.js"]
+    "scripts": ["choices.js", "background.js", "content-disposition.js"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "content-disposition": "^0.5.2"
+  },
+  "scripts": {
+    "build": "browserify content-disposition-in.js > ./content-disposition.js"
+  }
+}


### PR DESCRIPTION
This patch fixes/implements the following two Content-Disposition patterns:

1. Complex RFC-6266 headers

A example can be found at https://drive.google.com/file/d/0B7pIvhrJqP6xaGNkVldaeUpuRG8/view. This is an empty file named ```測試.txt```. It has such a header:
```
attachment;filename="__.txt";filename*=UTF-8''%E6%B8%AC%E8%A9%A6.txt
```
I uses a node.js library https://github.com/jshttp/content-disposition/ to handle it.

2. Raw UTF-8 filenames in the header value

An example can be found in this web page: https://www.csie.ntu.edu.tw/app/news.php?Sn=13101.  The PDF icon points to a link with this header:
```
attachment; filename=國立臺灣大學學生逕行修讀博士學位辦法1060609.pdf
```
Firefox re-encodes the header with ISO-8859-1, and I turn them back to UTF-8 with the escape+decodeURIComponent trick.

Also, escape+decodeURIComponent & unescape+encodeURIComponent trick is necessary to encode non-ASCII data with base64. It comes from https://stackoverflow.com/a/5396742/3786245. Some online materials claims that escape & unescape are deprecated. As per this MDN revision: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape$compare?locale=en-US&to=1305177&from=1246853, they are not deprecated.

I use the following steps to run the patched WebExtension:
```
npm install -g browserify
make all
web-ext run
```